### PR TITLE
Update packaging of the projects tests

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wildfly-getting-started-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -30,7 +30,7 @@
         <include>**/*.png</include>
       </includes>
     </fileSet>
-    <fileSet filtered="true" encoding="UTF-8">
+    <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/test/java</directory>
       <includes>
         <include>**/*.java</include>

--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/java/__defaultClassPrefix__ApplicationIT.java
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/java/__defaultClassPrefix__ApplicationIT.java
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-package org.wildfly.security.examples.test;
+package ${package};
 
 import static org.junit.Assert.assertEquals;
 
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
-public class SampleIT {
+public class ${defaultClassPrefix}ApplicationIT {
 
     @Test
     public void testHelloEndpoint() {

--- a/wildfly-getting-started-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/wildfly-getting-started-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,6 +1,6 @@
 #Sun Feb 19 10:28:23 GMT 2023
-package=it.pkg
-groupId=archetype.it
-artifactId=basic
-version=0.1-SNAPSHOT
+package=org.wildfly.examples
+groupId=org.wildfly.examples
+artifactId=getting-started
+version=1.0.0-SNAPSHOT
 defaultClassPrefix=GettingStarted


### PR DESCRIPTION
to use the same package and prefix that the application classes.